### PR TITLE
Public info

### DIFF
--- a/durak-bot/pyproject.toml
+++ b/durak-bot/pyproject.toml
@@ -5,5 +5,6 @@ description = "Durak bot trained via Reinforcement Learning"
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
+    "numpy>=2.4.6",
     "typer>=0.24.1",
 ]

--- a/durak-bot/src/adapter.py
+++ b/durak-bot/src/adapter.py
@@ -1,0 +1,149 @@
+from enum import IntEnum
+
+import numpy as np
+from action import Action
+from gamestate import Card, CardColor, CardValue, Phase, TablePair
+from interfaces import AgentInterface, PlayerInterface
+
+
+class Status(IntEnum):
+    Unknown = 0
+    MyCard = 1
+    OpponentCard = 2
+    OpenAttack = 3
+    DefendedAttack = 4
+    Defense = 5
+    InDeck = 6
+    Discarded = 7
+
+
+# Adapter for agents to be used in a standard Durak game
+# Keeps book about all known cards for the agent
+class AgentAdpater(PlayerInterface):
+    def __init__(self, trump: Card, agent: AgentInterface):
+        self.num_cards = len(CardColor) * len(CardValue)
+        self.trump = trump
+        trump_index = self._get_index_from_card(self.trump)
+        self.observations = np.zeros(self.num_cards + 7).astype(np.int8)
+        self.observations[trump_index] = Status.InDeck
+        self.passing_action = self.num_cards
+        self.agent = agent
+        self.turn = -1
+        self.tracked_cards = {
+            trump
+        }  # Includes any played or shown card. Their status can be traced exactly based on public information alone.
+
+    def OnTurn(
+        self,
+        attacking_card: Card | None,
+        hand_cards: list[Card],
+        legal_cards: list[Card],
+        phase: Phase,
+        table_pairs: list[TablePair],
+        discard_pile: list[Card],
+        draw_pile: int,
+        opponent_hand_size: int,
+        is_attacking: bool,
+        turn: int,
+    ) -> Action:
+        table_map = {pair.attack: pair.defense for pair in table_pairs}
+        table_defenses = [pair.defense for pair in table_pairs]
+
+        # Must play card on first move
+        is_new_turn = self.turn != turn
+        self.turn = turn
+        can_pass = (not is_attacking) or (not is_new_turn)
+
+        # Track agent hand cards
+        self.tracked_cards.update(hand_cards)
+
+        # Track any card on the table
+        for attack, defense in table_map.items():
+            self.tracked_cards.add(attack)
+            if defense:
+                self.tracked_cards.add(defense)
+
+        # Track any discarded card
+        self.tracked_cards.update(discard_pile)
+
+        # Update status for tracked cards
+        for card in self.tracked_cards:
+            if card in hand_cards:
+                status = Status.MyCard
+            elif card in discard_pile:
+                status = Status.Discarded
+            elif card in table_defenses:
+                status = Status.Defense
+            elif card in table_map and table_map[card] is None:
+                status = Status.OpenAttack
+            elif card in table_map and table_map[card] is not None:
+                status = Status.DefendedAttack
+            elif card == self.trump and draw_pile > 0:
+                status = Status.InDeck
+            else:
+                status = Status.OpponentCard
+
+            index = self._get_index_from_card(card)
+            self.observations[index] = status
+
+        # Generate action mask of legal moves
+        # Start will all-zeros
+        action_mask = np.zeros(self.num_cards + 1, dtype=np.int8)
+
+        # Passing is allowed if the agent is defending or it it not the first (attack) turn
+        action_mask[self.passing_action] = can_pass
+
+        # Set ones for legal cards if the agent can actually act
+        phase_actor_is_attacker = {
+            Phase.Attack: True,
+            Phase.ThrowIn: True,
+            Phase.Defense: False,
+        }
+        if phase_actor_is_attacker.get(phase) == is_attacking:
+            indices = [self._get_index_from_card(card) for card in legal_cards]
+            action_mask[indices] = 1
+
+        # Set global observations
+        self.observations[self.num_cards + 0] = int(self.trump.color.value)
+        self.observations[self.num_cards + 1] = int(phase.value)
+        self.observations[self.num_cards + 2] = int(is_attacking)
+        self.observations[self.num_cards + 3] = int(True)
+        self.observations[self.num_cards + 4] = int(len(hand_cards))
+        self.observations[self.num_cards + 5] = int(opponent_hand_size)
+        self.observations[self.num_cards + 6] = int(draw_pile)
+
+        # Copy to avoid agent writing to observations
+        obs = np.copy(self.observations)
+
+        # Generate observations dict for agent
+        obs_dict = {
+            "observations": obs,
+            "action_mask": action_mask,
+        }
+
+        # Return action from agent
+        action = self.agent.GetAction(obs_dict=obs_dict)
+        card = self._get_card_from_index(action)
+
+        # Agent played a card as attacker or defender
+        if card:
+            self.observations[action] = (
+                Status.OpenAttack if is_attacking else Status.Defense
+            )
+
+        return card
+
+    def GetName(self) -> str:
+        return self.agent.GetName()
+
+    def _get_index_from_card(self, card: Card) -> int:
+        # [Spades[6..Ace], Clubs[6..Ace], Hearts[6..Ace], Diamonds[6..Ace]]
+        return (card.color.value) * len(CardValue) + (card.value.value - 6)
+
+    def _get_card_from_index(self, index: int) -> Card | None:
+        if index == self.passing_action:
+            return None
+
+        color = CardColor(index // len(CardValue))
+        value = CardValue(index % len(CardValue) + 6)
+        return Card(value=value, color=color)

--- a/durak-bot/src/bot_lowest_card.py
+++ b/durak-bot/src/bot_lowest_card.py
@@ -1,6 +1,6 @@
 from interfaces import PlayerInterface
 from action import Action
-from gamestate import Card, CardColor, CardValue
+from gamestate import Card, CardColor, CardValue, Phase, TablePair
 
 
 # Simple bot which plays the lowest legal card by its numerical value.
@@ -11,6 +11,13 @@ class BotLowestCard(PlayerInterface):
         attacking_card: Card | None,
         hand_cards: list[Card],
         legal_cards: list[Card],
+        phase: Phase,
+        table_pairs: list[TablePair],
+        discard_pile: list[Card],
+        draw_pile: int,
+        opponent_hand_size: int,
+        is_attacking: bool,
+        turn: int,
     ) -> Action:
         chosen_card = None
         for card in legal_cards:
@@ -27,6 +34,14 @@ def test():
     attacking_card = Card(CardValue.JACK, CardColor.CLUBS)
 
     # Example with diamonds as trump
+    hand_cards = [
+        Card(CardValue.QUEEN, CardColor.CLUBS),
+        Card(CardValue.ACE, CardColor.CLUBS),
+        Card(CardValue.EIGHT, CardColor.DIAMONDS),
+        Card(CardValue.TEN, CardColor.DIAMONDS),
+        Card(CardValue.TEN, CardColor.SPADES),
+        Card(CardValue.TEN, CardColor.SPADES),
+    ]
     legal_cards = [
         Card(CardValue.QUEEN, CardColor.CLUBS),
         Card(CardValue.ACE, CardColor.CLUBS),
@@ -35,7 +50,27 @@ def test():
     ]
 
     bot = BotLowestCard()
-    result = bot.OnTurn(attacking_card, [], legal_cards)
+
+    phase = Phase.Attack
+    table_pairs = [TablePair(attack=attacking_card, defense=None)]
+    discard_pile = []
+    draw_pile = []
+    opponent_hand_size = 5
+    is_attacking = False
+    turn = 42
+
+    result = bot.OnTurn(
+        attacking_card=attacking_card,
+        hand_cards=hand_cards,
+        legal_cards=legal_cards,
+        phase=phase,
+        table_pairs=table_pairs,
+        discard_pile=discard_pile,
+        draw_pile=draw_pile,
+        opponent_hand_size=opponent_hand_size,
+        is_attacking=is_attacking,
+        turn=turn,
+    )
 
     # Card with the lowest CardValue, irrespective of trump color
     expected = Action(Card(CardValue.EIGHT, CardColor.DIAMONDS))

--- a/durak-bot/src/bot_lowest_card.py
+++ b/durak-bot/src/bot_lowest_card.py
@@ -1,12 +1,24 @@
 from interfaces import PlayerInterface
 from action import Action
-from gamestate import Card, CardColor, CardValue
+from gamestate import Card, CardColor, CardValue, Phase, TablePair
 
 
 # Simple bot which plays the lowest legal card by its numerical value.
 # If there are no legal cards to play, it will pass.
 class BotLowestCard(PlayerInterface):
-    def OnTurn(self, attacking_card: Card | None, legal_cards: list[Card]) -> Action:
+    def OnTurn(
+        self,
+        attacking_card: Card | None,
+        hand_cards: list[Card],
+        legal_cards: list[Card],
+        phase: Phase,
+        table_pairs: list[TablePair],
+        discard_pile: list[Card],
+        draw_pile: int,
+        opponent_hand_size: int,
+        is_attacking: bool,
+        turn: int,
+    ) -> Action:
         chosen_card = None
         for card in legal_cards:
             if chosen_card is None or card.value.value < chosen_card.value.value:
@@ -22,6 +34,14 @@ def test():
     attacking_card = Card(CardValue.JACK, CardColor.CLUBS)
 
     # Example with diamonds as trump
+    hand_cards = [
+        Card(CardValue.QUEEN, CardColor.CLUBS),
+        Card(CardValue.ACE, CardColor.CLUBS),
+        Card(CardValue.EIGHT, CardColor.DIAMONDS),
+        Card(CardValue.TEN, CardColor.DIAMONDS),
+        Card(CardValue.TEN, CardColor.SPADES),
+        Card(CardValue.TEN, CardColor.SPADES),
+    ]
     legal_cards = [
         Card(CardValue.QUEEN, CardColor.CLUBS),
         Card(CardValue.ACE, CardColor.CLUBS),
@@ -30,7 +50,27 @@ def test():
     ]
 
     bot = BotLowestCard()
-    result = bot.OnTurn(attacking_card, legal_cards)
+
+    phase = Phase.Attack
+    table_pairs = [TablePair(attack=attacking_card, defense=None)]
+    discard_pile = []
+    draw_pile = []
+    opponent_hand_size = 5
+    is_attacking = False
+    turn = 42
+
+    result = bot.OnTurn(
+        attacking_card=attacking_card,
+        hand_cards=hand_cards,
+        legal_cards=legal_cards,
+        phase=phase,
+        table_pairs=table_pairs,
+        discard_pile=discard_pile,
+        draw_pile=draw_pile,
+        opponent_hand_size=opponent_hand_size,
+        is_attacking=is_attacking,
+        turn=turn,
+    )
 
     # Card with the lowest CardValue, irrespective of trump color
     expected = Action(Card(CardValue.EIGHT, CardColor.DIAMONDS))

--- a/durak-bot/src/gamestate.py
+++ b/durak-bot/src/gamestate.py
@@ -1,7 +1,14 @@
 # gamestate.py
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import Enum, IntEnum
 import random
+
+
+class Phase(IntEnum):
+    Attack = 0
+    Defense = 1
+    ThrowIn = 2
+    Take = 3
 
 
 # Farben (Suits)

--- a/durak-bot/src/gamestate.py
+++ b/durak-bot/src/gamestate.py
@@ -1,8 +1,15 @@
 # gamestate.py
 
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import Enum, IntEnum
 import random
+
+
+class Phase(IntEnum):
+    Attack = 0
+    Defense = 1
+    ThrowIn = 2
+    Take = 3
 
 
 # Farben (Suits)

--- a/durak-bot/src/gamestate_test.py
+++ b/durak-bot/src/gamestate_test.py
@@ -1,6 +1,6 @@
 # gamestate_test.py
 
-from gamestate import GameState, Card, CardValue, CardColor
+from gamestate import GameState
 
 # TEST, OB ALLES FUNKTIONIERT:
 if __name__ == "__main__":

--- a/durak-bot/src/human_terminal_player.py
+++ b/durak-bot/src/human_terminal_player.py
@@ -1,7 +1,7 @@
 # human_terminal_player.py
 
 from action import Action
-from gamestate import Card
+from gamestate import Card, Phase, TablePair
 from interfaces import PlayerInterface
 
 COLOR = "\033[38;5;7m"
@@ -12,7 +12,19 @@ class HumanTerminalPlayer(PlayerInterface):
         self.name = input("Namen eingeben: ")
         super().__init__()
 
-    def OnTurn(self, attacking_card: Card | None, legal_cards: list[Card]) -> Action:
+    def OnTurn(
+        self,
+        attacking_card: Card | None,
+        hand_cards: list[Card],
+        legal_cards: list[Card],
+        phase: Phase,
+        table_pairs: list[TablePair],
+        discard_pile: list[Card],
+        draw_pile: int,
+        opponent_hand_size: int,
+        is_attacking: bool,
+        turn: int,
+    ) -> Action:
         if len(legal_cards) == 0:
             print(f"{COLOR}Dein Zug: [X: Passen / Aufnehmen]")
             input(f"{COLOR}> ")

--- a/durak-bot/src/human_terminal_player.py
+++ b/durak-bot/src/human_terminal_player.py
@@ -39,6 +39,8 @@ class HumanTerminalPlayer(PlayerInterface):
         print(f"{COLOR}Spielbare Karten:")
         self._print_cards_with_indexes(legal_cards)
 
+        print()
+
         print(f"{COLOR}Dein Zug: [X: Passen, Karte spielen: 0-{len(legal_cards) - 1}]")
 
         choice = input(f"{COLOR}> ").strip()

--- a/durak-bot/src/human_terminal_player.py
+++ b/durak-bot/src/human_terminal_player.py
@@ -1,7 +1,7 @@
 # human_terminal_player.py
 
 from action import Action
-from gamestate import Card
+from gamestate import Card, Phase, TablePair
 from interfaces import PlayerInterface
 
 COLOR = "\033[38;5;7m"
@@ -17,17 +17,24 @@ class HumanTerminalPlayer(PlayerInterface):
         attacking_card: Card | None,
         hand_cards: list[Card],
         legal_cards: list[Card],
+        phase: Phase,
+        table_pairs: list[TablePair],
+        discard_pile: list[Card],
+        draw_pile: int,
+        opponent_hand_size: int,
+        is_attacking: bool,
+        turn: int,
     ) -> Action:
-        print(f"{COLOR}Deine Handkarten: {len(hand_cards)}")
-        self._print_cards(hand_cards)
-
-        print()
-
         if len(legal_cards) == 0:
             print(f"{COLOR}Spielbare Karten: keine")
             print(f"{COLOR}Dein Zug: [X: Passen / Aufnehmen]")
             input(f"{COLOR}> ")
             return Action(card=None)
+
+        print(f"{COLOR}Deine Handkarten: {len(hand_cards)}")
+        self._print_cards(hand_cards)
+
+        print()
 
         print(f"{COLOR}Spielbare Karten:")
         self._print_cards_with_indexes(legal_cards)

--- a/durak-bot/src/human_terminal_player_test.py
+++ b/durak-bot/src/human_terminal_player_test.py
@@ -2,7 +2,7 @@
 
 import builtins
 
-from gamestate import GameState
+from gamestate import GameState, Phase
 from human_terminal_player import HumanTerminalPlayer
 
 
@@ -37,21 +37,51 @@ if __name__ == "__main__":
     player = HumanTerminalPlayer()
 
     attacker = gamestate.players[gamestate.attacker]
+    hand_cards = attacker.hand.cards.copy()
     legal_cards = gamestate.LegalAttackCards(attacker.hand.cards)
+    phase = Phase.Attack
+    table_pairs = gamestate.table.copy()
+    discard_pile = gamestate.discard_pile.copy()
+    draw_pile = len(gamestate.draw_pile)
+    opponent_hand_size = len(gamestate.players[1].hand.cards)
+    is_attacking = True
+    turn = 0
 
     old_input = builtins.input
 
     try:
         print("----- TEST: HUMAN TERMINAL PLAYER SPIELT KARTE -----")
         builtins.input = TestInput(["0"])
-        action = player.OnTurn(None, legal_cards)
+        action = player.OnTurn(
+            attacking_card=None,
+            hand_cards=hand_cards,
+            legal_cards=legal_cards,
+            phase=phase,
+            table_pairs=table_pairs,
+            discard_pile=discard_pile,
+            draw_pile=draw_pile,
+            opponent_hand_size=opponent_hand_size,
+            is_attacking=is_attacking,
+            turn=turn,
+        )
         print_action(action)
 
         print()
 
         print("----- TEST: HUMAN TERMINAL PLAYER PASST -----")
         builtins.input = TestInput(["x"])
-        action = player.OnTurn(None, legal_cards)
+        action = player.OnTurn(
+            attacking_card=None,
+            hand_cards=hand_cards,
+            legal_cards=legal_cards,
+            phase=phase,
+            table_pairs=table_pairs,
+            discard_pile=discard_pile,
+            draw_pile=draw_pile,
+            opponent_hand_size=opponent_hand_size,
+            is_attacking=is_attacking,
+            turn=turn,
+        )
         print_action(action)
 
     finally:

--- a/durak-bot/src/human_terminal_player_test.py
+++ b/durak-bot/src/human_terminal_player_test.py
@@ -2,7 +2,7 @@
 
 import builtins
 
-from gamestate import GameState
+from gamestate import GameState, Phase
 from human_terminal_player import HumanTerminalPlayer
 
 
@@ -34,6 +34,19 @@ if __name__ == "__main__":
     gamestate = GameState()
     gamestate.setup(2)
 
+    player = HumanTerminalPlayer()
+
+    attacker = gamestate.players[gamestate.attacker]
+    hand_cards = attacker.hand.cards.copy()
+    legal_cards = gamestate.LegalAttackCards(attacker.hand.cards)
+    phase = Phase.Attack
+    table_pairs = gamestate.table.copy()
+    discard_pile = gamestate.discard_pile.copy()
+    draw_pile = len(gamestate.draw_pile)
+    opponent_hand_size = len(gamestate.players[1].hand.cards)
+    is_attacking = True
+    turn = 0
+
     old_input = builtins.input
 
     try:
@@ -46,14 +59,36 @@ if __name__ == "__main__":
 
         print("----- TEST: HUMAN TERMINAL PLAYER SPIELT KARTE -----")
         builtins.input = TestInput(["0"])
-        action = player.OnTurn(None, hand_cards, legal_cards)
+        action = player.OnTurn(
+            attacking_card=None,
+            hand_cards=hand_cards,
+            legal_cards=legal_cards,
+            phase=phase,
+            table_pairs=table_pairs,
+            discard_pile=discard_pile,
+            draw_pile=draw_pile,
+            opponent_hand_size=opponent_hand_size,
+            is_attacking=is_attacking,
+            turn=turn,
+        )
         print_action(action)
 
         print()
 
         print("----- TEST: HUMAN TERMINAL PLAYER PASST -----")
         builtins.input = TestInput(["x"])
-        action = player.OnTurn(None, hand_cards, legal_cards)
+        action = player.OnTurn(
+            attacking_card=None,
+            hand_cards=hand_cards,
+            legal_cards=legal_cards,
+            phase=phase,
+            table_pairs=table_pairs,
+            discard_pile=discard_pile,
+            draw_pile=draw_pile,
+            opponent_hand_size=opponent_hand_size,
+            is_attacking=is_attacking,
+            turn=turn,
+        )
         print_action(action)
 
     finally:

--- a/durak-bot/src/interfaces.py
+++ b/durak-bot/src/interfaces.py
@@ -1,5 +1,5 @@
 from action import Action
-from gamestate import Card, GameState
+from gamestate import Card, GameState, Phase, TablePair
 
 
 class PlayerInterface:
@@ -11,6 +11,13 @@ class PlayerInterface:
         attacking_card: Card | None,
         hand_cards: list[Card],
         legal_cards: list[Card],
+        phase: Phase,
+        table_pairs: list[TablePair],
+        discard_pile: list[Card],
+        draw_pile: int,
+        opponent_hand_size: int,
+        is_attacking: bool,
+        turn: int,
     ) -> Action: ...
 
     def GetName(self) -> str: ...

--- a/durak-bot/src/interfaces.py
+++ b/durak-bot/src/interfaces.py
@@ -2,6 +2,12 @@ from action import Action
 from gamestate import Card, GameState, Phase, TablePair
 
 
+class AgentInterface:
+    def GetAction(self, obs_dict: dict) -> int: ...
+
+    def GetName(self) -> str: ...
+
+
 class PlayerInterface:
     # The logic implementation for this player's turn.
     # If 'attacking_card' is None: Your turn to attack.

--- a/durak-bot/src/interfaces.py
+++ b/durak-bot/src/interfaces.py
@@ -1,5 +1,5 @@
 from action import Action
-from gamestate import Card, GameState
+from gamestate import Card, GameState, Phase, TablePair
 
 
 class PlayerInterface:
@@ -7,7 +7,17 @@ class PlayerInterface:
     # If 'attacking_card' is None: Your turn to attack.
     # Otherwise: You are defending against 'card'.
     def OnTurn(
-        self, attacking_card: Card | None, legal_cards: list[Card]
+        self,
+        attacking_card: Card | None,
+        hand_cards: list[Card],
+        legal_cards: list[Card],
+        phase: Phase,
+        table_pairs: list[TablePair],
+        discard_pile: list[Card],
+        draw_pile: int,
+        opponent_hand_size: int,
+        is_attacking: bool,
+        turn: int,
     ) -> Action: ...
 
     def GetName(self) -> str: ...

--- a/durak-bot/src/two_player_game.py
+++ b/durak-bot/src/two_player_game.py
@@ -1,7 +1,7 @@
 # two_player_game.py
 
 from action import Action
-from gamestate import GameState, Card
+from gamestate import GameState, Card, Phase
 from interfaces import GameInterface, OutputInterface, PlayerInterface
 
 
@@ -15,10 +15,13 @@ class TwoPlayerGame(GameInterface):
         # "attack"   -> Angreifer spielt Karte oder beendet Angriff
         # "defend"   -> Verteidiger schlägt oder nimmt auf
         # "throw_in" -> Verteidiger nimmt auf, Angreifer darf nachwerfen
-        self.phase = "attack"
+        self.phase = Phase.Attack
 
     def Start(
-        self, players: list[PlayerInterface], output: OutputInterface, slow: bool
+        self,
+        players: list[PlayerInterface],
+        output: OutputInterface,
+        slow: bool = False,
     ):
         if len(players) != 2:
             raise ValueError("TwoPlayerGame needs exactly 2 players.")
@@ -33,15 +36,37 @@ class TwoPlayerGame(GameInterface):
             name = player.GetName()
             self.gamestate.set_player_name(i, name)
 
-        self.phase = "attack"
+        self.phase = Phase.Attack
         self._render()
 
         while not self.gamestate.is_game_over():
-            active_player = self.players[self._active_player_index()]
+            active_index = self._active_player_index()
+            active_player = self.players[active_index]
             attacking_card = self._current_attacking_card()
+            hand_cards = self.gamestate.players[active_index].hand.cards.copy()
             legal_cards = self._legal_cards()
+            phase = Phase.Attack
+            table_pairs = self.gamestate.table.copy()
+            discard_pile = self.gamestate.discard_pile.copy()
+            draw_pile = len(self.gamestate.draw_pile)
+            opponent_hand_size = len(
+                self.gamestate.players[(active_index + 1) % 2].hand.cards
+            )
+            is_attacking = active_index == self.gamestate.attacker
+            turn = self.gamestate.round
 
-            action = active_player.OnTurn(attacking_card, legal_cards)
+            action = active_player.OnTurn(
+                attacking_card=attacking_card,
+                hand_cards=hand_cards,
+                legal_cards=legal_cards,
+                phase=phase,
+                table_pairs=table_pairs,
+                discard_pile=discard_pile,
+                draw_pile=draw_pile,
+                opponent_hand_size=opponent_hand_size,
+                is_attacking=is_attacking,
+                turn=turn,
+            )
             self.OnAction(action)
             if slow:
                 input("Warte auf Enter...\n")  # Wait for player stepping
@@ -49,23 +74,20 @@ class TwoPlayerGame(GameInterface):
         self._render()
 
     def OnAction(self, action: Action):
-        if self.phase == "attack":
+        if self.phase == Phase.Attack:
             attacker = self.gamestate.players[self.gamestate.attacker].name
             self.output.OnAttack(attacker, action)
             self._handle_attack(action)
 
-        elif self.phase == "defend":
+        elif self.phase == Phase.Defense:
             defender = self.gamestate.players[self.gamestate.defender].name
             self.output.OnDefense(defender, action)
             self._handle_defense(action)
 
-        elif self.phase == "throw_in":
+        elif self.phase == Phase.ThrowIn:
             attacker = self.gamestate.players[self.gamestate.attacker].name
             self.output.OnAttack(attacker, action)
             self._handle_throw_in(action)
-
-        else:
-            raise ValueError(f"Unknown phase: {self.phase}")
 
         self._render()
 
@@ -80,36 +102,36 @@ class TwoPlayerGame(GameInterface):
                 raise ValueError("Attacker must play a card to start the round.")
 
             self._play_attack_card(action.card)
-            self.phase = "defend"
+            self.phase = Phase.Defense
             return
         # Tisch ist nicht leer. Angreifer kann Karten nachwerfen oder passen.
         else:
             if action.card is None:
                 self._finish_defended_round()
-                self.phase = "attack"
+                self.phase = Phase.Attack
                 return
 
             self._play_attack_card(action.card)
-            self.phase = "defend"
+            self.phase = Phase.Defense
             return
 
     def _handle_defense(self, action: Action) -> None:
         # None = Verteidiger nimmt auf.
         if action.card is None:
-            self.phase = "throw_in"
+            self.phase = Phase.ThrowIn
             return
 
         self._play_defense_card(action.card)
 
         # Wenn alles verteidigt ist, darf Angreifer wieder nachlegen oder passen.
         if self.gamestate.is_fully_defended():
-            self.phase = "attack"
+            self.phase = Phase.Attack
 
     def _handle_throw_in(self, action: Action) -> None:
         # None = Angreifer wirft nichts mehr nach.
         if action.card is None:
             self._finish_taken_round()
-            self.phase = "attack"
+            self.phase = Phase.Attack
             return
 
         self._play_attack_card(action.card)
@@ -168,13 +190,13 @@ class TwoPlayerGame(GameInterface):
     # ----------------------------
 
     def _active_player_index(self) -> int:
-        if self.phase == "defend":
+        if self.phase == Phase.Defense:
             return self.gamestate.defender
 
         return self.gamestate.attacker
 
     def _current_attacking_card(self) -> Card | None:
-        if self.phase == "defend":
+        if self.phase == Phase.Defense:
             return self.gamestate.last_open_attack()
 
         return None
@@ -183,12 +205,12 @@ class TwoPlayerGame(GameInterface):
         active_index = self._active_player_index()
         hand = self.gamestate.players[active_index].hand.cards
 
-        if self.phase in ["attack", "throw_in"]:
+        if self.phase in [Phase.Attack, Phase.ThrowIn]:
             if not self.gamestate.can_add_more_attack_cards():
                 return []
             return self.gamestate.LegalAttackCards(hand)
 
-        if self.phase == "defend":
+        if self.phase == Phase.Defense:
             return self.gamestate.LegalDefenseCards(hand)
 
         return []

--- a/durak-bot/src/two_player_game.py
+++ b/durak-bot/src/two_player_game.py
@@ -1,7 +1,7 @@
 # two_player_game.py
 
 from action import Action
-from gamestate import GameState, Card
+from gamestate import GameState, Card, Phase
 from interfaces import GameInterface, OutputInterface, PlayerInterface
 
 
@@ -15,10 +15,13 @@ class TwoPlayerGame(GameInterface):
         # "attack"   -> Angreifer spielt Karte oder beendet Angriff
         # "defend"   -> Verteidiger schlägt oder nimmt auf
         # "throw_in" -> Verteidiger nimmt auf, Angreifer darf nachwerfen
-        self.phase = "attack"
+        self.phase = Phase.Attack
 
     def Start(
-        self, players: list[PlayerInterface], output: OutputInterface, slow: bool
+        self,
+        players: list[PlayerInterface],
+        output: OutputInterface,
+        slow: bool = False,
     ):
         if len(players) != 2:
             raise ValueError("TwoPlayerGame needs exactly 2 players.")
@@ -33,16 +36,37 @@ class TwoPlayerGame(GameInterface):
             name = player.GetName()
             self.gamestate.set_player_name(i, name)
 
-        self.phase = "attack"
+        self.phase = Phase.Attack
         self._render()
 
         while not self.gamestate.is_game_over():
-            active_player = self.players[self._active_player_index()]
+            active_index = self._active_player_index()
+            active_player = self.players[active_index]
             attacking_card = self._current_attacking_card()
+            hand_cards = self.gamestate.players[active_index].hand.cards.copy()
             legal_cards = self._legal_cards()
-            hand_cards = self.gamestate.players[self._active_player_index()].hand.cards
+            phase = Phase.Attack
+            table_pairs = self.gamestate.table.copy()
+            discard_pile = self.gamestate.discard_pile.copy()
+            draw_pile = len(self.gamestate.draw_pile)
+            opponent_hand_size = len(
+                self.gamestate.players[(active_index + 1) % 2].hand.cards
+            )
+            is_attacking = active_index == self.gamestate.attacker
+            turn = self.gamestate.round
 
-            action = active_player.OnTurn(attacking_card, hand_cards, legal_cards)
+            action = active_player.OnTurn(
+                attacking_card=attacking_card,
+                hand_cards=hand_cards,
+                legal_cards=legal_cards,
+                phase=phase,
+                table_pairs=table_pairs,
+                discard_pile=discard_pile,
+                draw_pile=draw_pile,
+                opponent_hand_size=opponent_hand_size,
+                is_attacking=is_attacking,
+                turn=turn,
+            )
             self.OnAction(action)
             if slow:
                 input("Warte auf Enter...\n")  # Wait for player stepping
@@ -50,23 +74,20 @@ class TwoPlayerGame(GameInterface):
         self._render()
 
     def OnAction(self, action: Action):
-        if self.phase == "attack":
+        if self.phase == Phase.Attack:
             attacker = self.gamestate.players[self.gamestate.attacker].name
             self.output.OnAttack(attacker, action)
             self._handle_attack(action)
 
-        elif self.phase == "defend":
+        elif self.phase == Phase.Defense:
             defender = self.gamestate.players[self.gamestate.defender].name
             self.output.OnDefense(defender, action)
             self._handle_defense(action)
 
-        elif self.phase == "throw_in":
+        elif self.phase == Phase.ThrowIn:
             attacker = self.gamestate.players[self.gamestate.attacker].name
             self.output.OnAttack(attacker, action)
             self._handle_throw_in(action)
-
-        else:
-            raise ValueError(f"Unknown phase: {self.phase}")
 
         self._render()
 
@@ -81,36 +102,36 @@ class TwoPlayerGame(GameInterface):
                 raise ValueError("Attacker must play a card to start the round.")
 
             self._play_attack_card(action.card)
-            self.phase = "defend"
+            self.phase = Phase.Defense
             return
         # Tisch ist nicht leer. Angreifer kann Karten nachwerfen oder passen.
         else:
             if action.card is None:
                 self._finish_defended_round()
-                self.phase = "attack"
+                self.phase = Phase.Attack
                 return
 
             self._play_attack_card(action.card)
-            self.phase = "defend"
+            self.phase = Phase.Defense
             return
 
     def _handle_defense(self, action: Action) -> None:
         # None = Verteidiger nimmt auf.
         if action.card is None:
-            self.phase = "throw_in"
+            self.phase = Phase.ThrowIn
             return
 
         self._play_defense_card(action.card)
 
         # Wenn alles verteidigt ist, darf Angreifer wieder nachlegen oder passen.
         if self.gamestate.is_fully_defended():
-            self.phase = "attack"
+            self.phase = Phase.Attack
 
     def _handle_throw_in(self, action: Action) -> None:
         # None = Angreifer wirft nichts mehr nach.
         if action.card is None:
             self._finish_taken_round()
-            self.phase = "attack"
+            self.phase = Phase.Attack
             return
 
         self._play_attack_card(action.card)
@@ -191,13 +212,13 @@ class TwoPlayerGame(GameInterface):
                 self.output.OnDrawCards(player.name, before, after)
 
     def _active_player_index(self) -> int:
-        if self.phase == "defend":
+        if self.phase == Phase.Defense:
             return self.gamestate.defender
 
         return self.gamestate.attacker
 
     def _current_attacking_card(self) -> Card | None:
-        if self.phase == "defend":
+        if self.phase == Phase.Defense:
             return self.gamestate.last_open_attack()
 
         return None
@@ -206,12 +227,12 @@ class TwoPlayerGame(GameInterface):
         active_index = self._active_player_index()
         hand = self.gamestate.players[active_index].hand.cards
 
-        if self.phase in ["attack", "throw_in"]:
+        if self.phase in [Phase.Attack, Phase.ThrowIn]:
             if not self.gamestate.can_add_more_attack_cards():
                 return []
             return self.gamestate.LegalAttackCards(hand)
 
-        if self.phase == "defend":
+        if self.phase == Phase.Defense:
             return self.gamestate.LegalDefenseCards(hand)
 
         return []

--- a/durak-bot/src/two_player_game_test.py
+++ b/durak-bot/src/two_player_game_test.py
@@ -3,12 +3,25 @@
 from action import Action
 from interfaces import PlayerInterface, OutputInterface
 from two_player_game import TwoPlayerGame
+from gamestate import Card, Phase, TablePair
 
 # Langer basic Text-Output der Spieldaten als Test, ob alles klappt.
 
 
 class TestPlayer(PlayerInterface):
-    def OnTurn(self, attacking_card, hand_cards, legal_cards):
+    def OnTurn(
+        self,
+        attacking_card: Card | None,
+        hand_cards: list[Card],
+        legal_cards: list[Card],
+        phase: Phase,
+        table_pairs: list[TablePair],
+        discard_pile: list[Card],
+        draw_pile: int,
+        opponent_hand_size: int,
+        is_attacking: bool,
+        turn: int,
+    ) -> Action:
         # Wenn es legale Karten gibt, spiele einfach die erste.
         # Wenn nicht, gib None zurück.
         if legal_cards:

--- a/durak-bot/src/two_player_game_test.py
+++ b/durak-bot/src/two_player_game_test.py
@@ -3,12 +3,25 @@
 from action import Action
 from interfaces import PlayerInterface, OutputInterface
 from two_player_game import TwoPlayerGame
+from gamestate import Card, Phase, TablePair
 
 # Langer basic Text-Output der Spieldaten als Test, ob alles klappt.
 
 
 class TestPlayer(PlayerInterface):
-    def OnTurn(self, attacking_card, legal_cards):
+    def OnTurn(
+        self,
+        attacking_card: Card | None,
+        hand_cards: list[Card],
+        legal_cards: list[Card],
+        phase: Phase,
+        table_pairs: list[TablePair],
+        discard_pile: list[Card],
+        draw_pile: int,
+        opponent_hand_size: int,
+        is_attacking: bool,
+        turn: int,
+    ) -> Action:
         # Wenn es legale Karten gibt, spiele einfach die erste.
         # Wenn nicht, gib None zurück.
         if legal_cards:

--- a/durak-bot/uv.lock
+++ b/durak-bot/uv.lock
@@ -37,11 +37,15 @@ name = "durak-bot"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "numpy" },
     { name = "typer" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "typer", specifier = ">=0.24.1" }]
+requires-dist = [
+    { name = "numpy", specifier = ">=2.4.6" },
+    { name = "typer", specifier = ">=0.24.1" },
+]
 
 [[package]]
 name = "markdown-it-py"
@@ -62,6 +66,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Verwendet ein einheitliches Phasen-Enum (Angriff, Verteidigung etc.)

Erweitert das PlayerInterface um die gesamten öffentlichen Informationen, also Karten auf dem Tisch, abgelegte Karten, wer gerade am Zug is etc. Diese Informationen nur anhand der aktuell ausgespielten Karte zu rekonstruieren, wäre sehr aufwändig.

Und es fügt den AgentenAdapter diesem Repo hinzu, da dieser später die trainierten Agenten dem Spiel zur Verfügung stellt. 

Alle Tests sind OK.