### PR TITLE
feat: crosstable eval

### DIFF
--- a/packages/dqn/src/dqn/config.py
+++ b/packages/dqn/src/dqn/config.py
@@ -66,12 +66,12 @@ def dqn_config(params: dict, opponents: dict, checkpoint_path: str) -> DQNConfig
 
     rl_module_specs = {
         policy_id: RLModuleSpec(
-            module_class=module,
+            module_class=agent.module_class,
             inference_only=True,
             observation_space=tmp_env.observation_space,
             action_space=tmp_env.action_space,
         )
-        for policy_id, module in opponents.items()
+        for policy_id, agent in opponents.items()
     }
 
     rl_module_specs["dqn"] = RLModuleSpec(

--- a/packages/dqn/src/dqn/crosstable.py
+++ b/packages/dqn/src/dqn/crosstable.py
@@ -1,0 +1,56 @@
+from dqn.interfaces import AgentInterface
+from dqn.test import test
+
+
+def crosstable(
+    env_factory: callable,
+    agents: list[AgentInterface],
+    n_episodes: int,
+) -> dict:
+    results = {
+        agent.GetName(): {agent.GetName(): None for agent in agents} for agent in agents
+    }
+
+    for i, agent in enumerate(agents):
+        for opponent in agents[i:]:
+            result = test(
+                env_factory=env_factory,
+                agent=agent,
+                opponent=opponent,
+                n_episodes=n_episodes,
+            )
+            results[agent.GetName()][opponent.GetName()] = result
+            results[opponent.GetName()][agent.GetName()] = (result[1], result[0])
+
+    return results
+
+
+if __name__ == "__main__":
+    from prettytable import PrettyTable
+
+    from dqn.durak_env import DurakEnv
+    from dqn.high_card_agent import HighCardAgent
+    from dqn.interpolation_agent import InterpolationAgent
+    from dqn.low_card_agent import LowCardAgent
+    from dqn.random_agent import RandomAgent
+    from dqn.trump_fish_agent import TrumpFishAgent
+
+    agents = [
+        RandomAgent(),
+        HighCardAgent(),
+        LowCardAgent(),
+        TrumpFishAgent(),
+        InterpolationAgent(),
+    ]
+
+    results = crosstable(env_factory=lambda: DurakEnv(), agents=agents, n_episodes=1000)
+    table = PrettyTable()
+    table.field_names = ["Matchups"] + [agent.GetName() for agent in agents]
+    for agent in agents:
+        res = [agent.GetName()] + [
+            f"{(results[agent.GetName()][opponent.GetName()][0] * 100):>5.2f}%"
+            for opponent in agents
+        ]
+        table.add_row(res)
+
+    print(table)

--- a/packages/dqn/src/dqn/dqn_agent.py
+++ b/packages/dqn/src/dqn/dqn_agent.py
@@ -136,10 +136,11 @@ class DQNAgent(AgentInterface):
         )
         self.module = spec.build()
         self.module.restore_from_path(module_path)
+        self.name = "DQNAgent"
         assert isinstance(self.module, DQNMaskedRLModule), type(self.module)
 
     def GetName(self) -> str:
-        return "DQNAgent"
+        return self.name
 
     # Get agent action by forwarding the call to the RLModule
     def GetAction(self, obs_dict: dict) -> int:

--- a/packages/dqn/src/dqn/high_card_agent.py
+++ b/packages/dqn/src/dqn/high_card_agent.py
@@ -20,6 +20,7 @@ class HighCardAgent(AgentInterface):
     def __init__(
         self,
     ):
+        self.module_class = HighCardRLModule
         self.module = HighCardRLModule()
 
     def GetName(self) -> str:

--- a/packages/dqn/src/dqn/interpolation_agent.py
+++ b/packages/dqn/src/dqn/interpolation_agent.py
@@ -19,6 +19,7 @@ MAX_DRAW_PILE_SIZE = 24  # 36 Karten - 2 * 6 Starthandkarten
 
 class InterpolationAgent(AgentInterface):
     def __init__(self):
+        self.module_class = InterpolationRLModule
         self.module = InterpolationRLModule()
 
     def GetName(self) -> str:

--- a/packages/dqn/src/dqn/low_card_agent.py
+++ b/packages/dqn/src/dqn/low_card_agent.py
@@ -20,6 +20,7 @@ class LowCardAgent(AgentInterface):
     def __init__(
         self,
     ):
+        self.module_class = LowCardRLModule
         self.module = LowCardRLModule()
 
     def GetName(self) -> str:

--- a/packages/dqn/src/dqn/main.py
+++ b/packages/dqn/src/dqn/main.py
@@ -4,16 +4,20 @@ from datetime import datetime
 from pathlib import Path
 
 import torch
+from prettytable import PrettyTable
 from torch.utils.tensorboard import SummaryWriter
 from tqdm import tqdm
 
 from dqn.config import dqn_config, save_parameters, set_epsilon
+from dqn.crosstable import crosstable
+from dqn.dqn_agent import DQNAgent
+from dqn.durak_env import DurakEnv
 from dqn.epsilon_decay import EpsilonDecay
-from dqn.high_card_agent import HighCardRLModule
-from dqn.interpolation_agent import InterpolationRLModule
-from dqn.low_card_agent import LowCardRLModule
-from dqn.random_agent import RandomMaskedRLModule
-from dqn.trump_fish_agent import TrumpFishRLModule
+from dqn.high_card_agent import HighCardAgent
+from dqn.interpolation_agent import InterpolationAgent
+from dqn.low_card_agent import LowCardAgent
+from dqn.random_agent import RandomAgent
+from dqn.trump_fish_agent import TrumpFishAgent
 
 
 def main():
@@ -48,14 +52,15 @@ def main():
         "self_play_interval": 64,
         "self_play_recency_bias": 0.25,
         "self_play_gate": 0.50,
+        "crosstable_iterations": 100,
     }
 
     opponents = {
-        "random": RandomMaskedRLModule,
-        "trump_fish": TrumpFishRLModule,
-        "interpolation": InterpolationRLModule,
-        "low-card": LowCardRLModule,
-        "high_card": HighCardRLModule,
+        "random": RandomAgent(),
+        "trump_fish": TrumpFishAgent(),
+        "interpolation": InterpolationAgent(),
+        "low-card": LowCardAgent(),
+        "high_card": HighCardAgent(),
     }
 
     checkpoint_path = Path(f"./checkpoints/{experiment_name}").resolve()
@@ -85,6 +90,9 @@ def main():
             epsilon_decay=epsilon_decay,
             iterations=params["iterations"],
         )
+        checkpoint_agents = collect_checkpoints(checkpoint_path)
+        agents = checkpoint_agents + list(opponents.values())
+        evaluate(agents=agents, n_episodes=params["crosstable_iterations"])
 
     except KeyboardInterrupt:
         print("Exiting...")
@@ -145,6 +153,39 @@ def train(w, algorithm, epsilon_decay, iterations):
             pbar.set_description(
                 f"Training | Epsilon: {epsilon:.2f} Last eval: {(last_eval * 100.0):.1f}%"
             )
+
+
+def collect_checkpoints(path):
+    print(f"Collecting all checkpoint versions from {path}")
+    agents = []
+    for d in path.iterdir():
+        if not d.is_dir():
+            continue
+
+        name = d.name
+        path = d / "learner_group" / "learner" / "rl_module" / "dqn"
+        agent = DQNAgent(path=path)
+        agent.name = name
+        agents.append(agent)
+
+    return agents
+
+
+def evaluate(agents, n_episodes):
+    print(f"Starting evaluation crosstable with {len(agents)} agents")
+    results = crosstable(
+        env_factory=lambda: DurakEnv(), agents=agents, n_episodes=n_episodes
+    )
+    table = PrettyTable()
+    table.field_names = ["Matchups"] + [agent.GetName() for agent in agents]
+    for agent in agents:
+        res = [agent.GetName()] + [
+            f"{(results[agent.GetName()][opponent.GetName()][0] * 100):>5.2f}%"
+            for opponent in agents
+        ]
+        table.add_row(res)
+
+    print(table)
 
 
 def set_eval_interval(algorithm, value):

--- a/packages/dqn/src/dqn/random_agent.py
+++ b/packages/dqn/src/dqn/random_agent.py
@@ -14,6 +14,7 @@ class RandomAgent(AgentInterface):
     def __init__(
         self,
     ):
+        self.module_class = RandomMaskedRLModule
         self.module = RandomMaskedRLModule()
 
     def GetName(self) -> str:

--- a/packages/dqn/src/dqn/test.py
+++ b/packages/dqn/src/dqn/test.py
@@ -1,17 +1,21 @@
 from tqdm import tqdm
 
+from dqn.interfaces import AgentInterface
+
 
 def test(
     env_factory: callable,
-    agent,
-    opponent,
+    agent: AgentInterface,
+    opponent: AgentInterface,
     n_episodes: int,
 ) -> (float, float, float):
     env = env_factory()
 
     wins = 0
-    draws = 0
     losses = 0
+
+    agent_name = agent.GetName()
+    opponent_name = opponent.GetName()
 
     agent_id = env.possible_agents[0]
     opponent_id = env.possible_agents[1]
@@ -21,12 +25,13 @@ def test(
         opponent_id: opponent,
     }
 
-    for _ in tqdm(range(n_episodes)):
+    print(f"{agent_name} vs {opponent_name}")
+    for i in tqdm(range(n_episodes)):
         obss, infos = env.reset()
 
         while env.agents:
             actions = {
-                agent_id: agents_dict[agent_id].get_action(obss[agent_id])
+                agent_id: agents_dict[agent_id].GetAction(obss[agent_id])
                 for agent_id in obss.keys()
             }
 
@@ -35,13 +40,10 @@ def test(
         winner = env._get_winner()
         if winner == agent_id:
             wins += 1
-        elif winner == opponent_id:
+        else:
             losses += 1
-        elif winner is None:
-            draws += 1
 
     return (
         wins / n_episodes,
-        draws / n_episodes,
         losses / n_episodes,
     )

--- a/packages/dqn/src/dqn/trump_fish_agent.py
+++ b/packages/dqn/src/dqn/trump_fish_agent.py
@@ -24,6 +24,7 @@ class TrumpFishAgent(AgentInterface):
     def __init__(
         self,
     ):
+        self.module_class = TrumpFishRLModule
         self.module = TrumpFishRLModule()
 
     def GetName(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "cli",
     "durak",
     "dqn",
+    "prettytable>=3.17.0",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -915,6 +915,7 @@ dependencies = [
     { name = "cli" },
     { name = "dqn" },
     { name = "durak" },
+    { name = "prettytable" },
 ]
 
 [package.metadata]
@@ -922,6 +923,7 @@ requires-dist = [
     { name = "cli", editable = "packages/cli" },
     { name = "dqn", editable = "packages/dqn" },
     { name = "durak", editable = "packages/durak" },
+    { name = "prettytable", specifier = ">=3.17.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Nach Abschluss des Trainings wird nun eine Kreuztabelle aller trainierten Checkpoints und der Baseline-Agenten produziert. Die Anzahl an Spiele kann via `crosstable_iterations` festgelegt werden.

Die Tabelle liest sich: Zeile gewinnt gegen Spalte in X% der Spiele. Also gewinnt HighCardAgent 21% gegen version_1. (Die konkreten Werte hier stammen nur aus einem minimalen Training)

<img width="1537" height="291" alt="1781117882_grim" src="https://github.com/user-attachments/assets/54146166-b8d6-4d02-9c7c-78c63a59d96f" />

Closes #6 