### PR TITLE
feat: fault tolerance | ray dashboard

### DIFF
--- a/packages/dqn/docker-compose.yaml
+++ b/packages/dqn/docker-compose.yaml
@@ -21,6 +21,8 @@ services:
       - PYTHONPATH=/dqn/src:/durak/src
       - CUDA_VISIBLE_DEVICES=0
     shm_size: '16gb'
+    cap_add:
+    - SYS_PTRACE
 
   amd-trainer:
     container_name: amd-trainer
@@ -44,6 +46,8 @@ services:
       - HIP_VISIBLE_DEVICES=0
       - ROCR_VISIBLE_DEVICES=0
     shm_size: '16gb'
+    cap_add:
+    - SYS_PTRACE
 
   tensorboard:
     container_name: tensorboard

--- a/packages/dqn/src/dqn/config.py
+++ b/packages/dqn/src/dqn/config.py
@@ -31,7 +31,9 @@ register_env(
 
 def set_epsilon(epsilon: float, algorithm) -> None:
     algorithm.env_runner_group.foreach_env_runner(
-        lambda w: w.module["dqn"].model_config.update({"epsilon": epsilon})
+        lambda w: w.module["dqn"].model_config.update({"epsilon": epsilon}),
+        healthy_only=True,
+        timeout_seconds=30,
     )
 
 
@@ -118,6 +120,7 @@ def dqn_config(params: dict, opponents: dict, checkpoint_path: str) -> DQNConfig
         .env_runners(
             num_env_runners=params["num_env_runners"],
             num_envs_per_env_runner=params["num_envs_per_env_runner"],
+            sample_timeout_s=120,
         )
         .training(
             replay_buffer_config={
@@ -146,6 +149,7 @@ def dqn_config(params: dict, opponents: dict, checkpoint_path: str) -> DQNConfig
             evaluation_duration_unit="episodes",
             evaluation_duration=params["eval_episodes"],
             evaluation_config={"explore": False},
+            evaluation_parallel_to_training=True,
         )
         .callbacks(
             on_train_result=lambda algorithm, metrics_logger, result: (
@@ -153,6 +157,15 @@ def dqn_config(params: dict, opponents: dict, checkpoint_path: str) -> DQNConfig
                     algorithm=algorithm, metrics_logger=metrics_logger, result=result
                 )
             )
+        )
+        .fault_tolerance(
+            restart_failed_env_runners=True,
+            restart_failed_sub_environments=True,
+            env_runner_health_probe_timeout_s=30.0,
+            env_runner_restore_timeout_s=180.0,
+            max_num_env_runner_restarts=1000,
+            num_consecutive_env_runner_failures_tolerance=100,
+            delay_between_env_runner_restarts_s=5.0,
         )
     )
 

--- a/packages/dqn/src/dqn/main.py
+++ b/packages/dqn/src/dqn/main.py
@@ -3,6 +3,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
+import ray
 import torch
 from prettytable import PrettyTable
 from torch.utils.tensorboard import SummaryWriter
@@ -23,6 +24,12 @@ from dqn.trump_fish_agent import TrumpFishAgent
 def main():
     print(f"GPU supported: {torch.cuda.is_available()}")
 
+    ray.init(
+        include_dashboard=True,
+        dashboard_host="0.0.0.0",
+        dashboard_port=8265,
+    )
+
     experiment_name = f"selfplay_{datetime.now()}"
     params = {
         "learning_rate": 1e-4,
@@ -39,7 +46,7 @@ def main():
         "num_steps_sampled_before_learning_starts": 65536 * 16,
         "target_network_update_freq": 4,
         "td_error_loss_fn": "huber",
-        "n_step": 5,
+        "n_step": 1,
         "adam_epsilon": 1e-3,
         "grad_clip": 4.0,
         "grad_clip_by": "global_norm",


### PR DESCRIPTION
Warum der Trainer in machen Fällen mitten im Training stoppt:

Die konkrete Variante des ReplayBuffers für Multiagenten kommt nicht gut damit zurecht, wenn n_step > 1 und Spiele nicht sehr lange Episoden ergeben. An dieser Stelle haben wir eine Endlosschleife getroffen.

Grundsätzliche Lösung wäre es n_step auf 1 zu setzen.

Zusätzlich dazu haben wir unter Port 8265 auch das Ray Dashboard zum Debuggen und Monitoring der Worker.
Sollten Worker aus anderen Fällen in ein Timeout geraten, werden diese automatisch neu gestartet.
